### PR TITLE
knob changes lfo speed smoothly

### DIFF
--- a/main.c
+++ b/main.c
@@ -1000,13 +1000,13 @@ int main() {
               scale_quantize_voltage(config->quantization, config->root_note,
                                      config->v_oct, out->voltage_set);
           break;
-      case MODE_NOTE:
+        case MODE_NOTE:
           // mode pitch will set the voltage based on midi note
           // button + knob will override and set the voltage
           if (knob_val != -1 && button_val) {
-              // change the set voltage
-              out->voltage_set = linlin(knob_val, 0.0f, 1023.0f,
-                                        config->min_voltage, config->max_voltage);
+            // change the set voltage
+            out->voltage_set = linlin(knob_val, 0.0f, 1023.0f,
+                                      config->min_voltage, config->max_voltage);
           }
           // slew the voltage
           out->voltage_current = Slew_process(&out->slew, out->voltage_set, ct);

--- a/main.c
+++ b/main.c
@@ -86,6 +86,8 @@ const uint8_t button_pins[9] = {1, 8, 20, 21, 22, 26, 27, 28, 29};
 uint8_t button_values[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
 uint32_t time_per_iteration = 0;
 uint32_t timer_per[32];
+uint32_t lfo_ct_last[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+float lfo_index_acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 // const clockDivisions = [
 //   "/512", "/256", "/128", "/64", "/32", "/16", "/8", "/4", "/2", "x1", "x2",
 //   "x3", "x4", "x6", "x8", "x12", "x16", "x24", "x48"
@@ -789,6 +791,9 @@ int main() {
   SimpleTimer_start(&pool_timer[13]);
 
   uint32_t ct_last = ct;
+  for (uint8_t i = 0; i < 8; i++) {
+      lfo_ct_last[i] = ct;
+  }
 
   printf("Starting main loop\n");
 
@@ -946,35 +951,34 @@ int main() {
       switch (config->mode) {
         case MODE_LFO:
           // mode lfo will set the voltage based on lfo
-            float adjusted_ct = ct;
-            float ct_n;
-            float old_period;
 
-            if (knob_val != -1) {
-                old_period = config->lfo_period;
+          if (knob_val != -1) {
+            float old_period = config->lfo_period;
 
-                config->lfo_period = 10.1f - linlin(knob_val, 0.00001f, 1023.0f,
+            config->lfo_period = 10.1f - linlin(knob_val, 0.00001f, 1023.0f,
                                                     0.1f, 10.f);
-                printf("JB: ------------------------\n");
-                printf("JB: changed lfo %d period: %f -> %f\n", i, old_period, config->lfo_period);
+            // printf("changed lfo %d period: %f -> %f\n", i, old_period, config->lfo_period);
+          }
 
-                // NB: normalized `ct` (between 0 & 1), w/ phase correction
-                ct_n = fmod(ct / (old_period * 1000.0f), 1.0f);
-                adjusted_ct = (ct_n * (config->lfo_period * 1000.f));
+          // NB: `step` is basically how much % of the period got elapsed
+          uint32_t elapsed_ms = ct - lfo_ct_last[i];
+          lfo_ct_last[i] = ct;
+          float step = elapsed_ms / (config->lfo_period * 1000.f);
+          lfo_index_acc[i] = fmod(lfo_index_acc[i] + step, 1.f);
 
-                printf("JB: adjusted ct: %d -> %f x %f = %f\n", ct, ct_n, (config->lfo_period * 1000.f), adjusted_ct);
-            }
+          // if (button_val) {
+          //   printf("elapsed=%d ms, p=%f ms, pct=%f\n", elapsed_ms, (config->lfo_period * 1000.f) , step);
+          // }
 
-            out->voltage_set =
-                get_lfo_value(config->lfo_waveform, adjusted_ct, config->lfo_period * 1000,
-                              config->min_voltage, config->max_voltage, 0,
-                              &out->noise, &out->slew_lfo);
-
-            // quantize
-            out->voltage_current =
-                scale_quantize_voltage(config->quantization, config->root_note,
-                                       config->v_oct, out->voltage_set);
-            break;
+          out->voltage_set =
+              get_lfo_value(config->lfo_waveform, lfo_index_acc[i] * 1000, 1 * 1000,
+                            config->min_voltage, config->max_voltage, 0,
+                            &out->noise, &out->slew_lfo);
+          // quantize
+          out->voltage_current =
+              scale_quantize_voltage(config->quantization, config->root_note,
+                                     config->v_oct, out->voltage_set);
+          break;
       case MODE_NOTE:
           // mode pitch will set the voltage based on midi note
           // button + knob will override and set the voltage

--- a/main.c
+++ b/main.c
@@ -973,10 +973,9 @@ int main() {
       switch (config->mode) {
         case MODE_LFO:
           // mode lfo will set the voltage based on lfo
+          float old_period = config->lfo_period;
 
           if (knob_val != -1) {
-            float old_period = config->lfo_period;
-
             config->lfo_period = 10.1f - linlin(knob_val, 0.00001f, 1023.0f,
                                                     0.1f, 10.f);
             // printf("changed lfo %d period: %f -> %f\n", i, old_period, config->lfo_period);
@@ -985,7 +984,7 @@ int main() {
           // NB: `step` is basically how much % of the period got elapsed
           uint32_t elapsed_ms = ct - lfo_ct_last[i];
           lfo_ct_last[i] = ct;
-          float step = elapsed_ms / (config->lfo_period * 1000.f);
+          float step = elapsed_ms / (old_period * 1000.f);
           lfo_index_acc[i] = fmod(lfo_index_acc[i] + step, 1.f);
 
           // if (button_val) {


### PR DESCRIPTION
hey!

i struggled a bit to have changing the lfo speed not mess up the phase, i.e. the relative position of `ct` in the current lfo period.

and then i remembered i already tackled a similar use-case in the past and just reproduced my logic.

the key idea is to not call `get_lfo_value` with `ct` but instead use an accumulaotr over a normalized representation of the distance traveled in the period.

as the accumulator represents a percentage, it's normalized and no phase issue occurs as we change the LFO freq.

---

anyhow, i'm pretty sure there are at ways to do it. i won't be mad if you decide on an alt approach.

if you merge this PR, tough, please "squash" to only grab it as a single commit (as there are a few whoopsies in there).