### PR TITLE
composite usb mode (serial + midi)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,13 @@ target_link_libraries(${PROJECT_NAME}
     tinyusb_device
     tinyusb_board
 )
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    pico_enable_stdio_usb(${PROJECT_NAME} 0)
+    add_compile_definitions(PICO_STDIO_USB_ENABLE=0)
+else()
+    pico_enable_stdio_usb(${PROJECT_NAME} 1)
+    add_compile_definitions(PICO_STDIO_USB_ENABLE=1)
+endif()
 pico_enable_stdio_uart(${PROJECT_NAME} 1)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ pico_sdk_init()
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
 
 # Tell CMake where to find the executable source file
-add_executable(${PROJECT_NAME} 
+add_executable(${PROJECT_NAME}
     main.c
     ${CMAKE_CURRENT_LIST_DIR}/lib/hw_config.c
     ${CMAKE_CURRENT_LIST_DIR}/lib/pcg_basic.c
@@ -45,7 +45,7 @@ pico_generate_pio_header(yoctocore ${CMAKE_CURRENT_LIST_DIR}/lib/uart_rx.pio)
 pico_add_extra_outputs(${PROJECT_NAME})
 
 # Link to pico_stdlib (gpio, time, etc. functions)
-target_link_libraries(${PROJECT_NAME} 
+target_link_libraries(${PROJECT_NAME}
     pico_stdlib
     pico_multicore
     FatFs_SPI
@@ -80,7 +80,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
     # pins
     SDCARD_CMD_GPIO=11
-    SDCARD_D0_GPIO=12 
+    SDCARD_D0_GPIO=12
     I2C0_SDA_PIN=4
     I2C0_SCL_PIN=5
     I2C1_SDA_PIN=2
@@ -93,7 +93,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     WS2812_PIN=7
     WS2812_SM=2
     WS2812_NUM_LEDS=16
-    
+
     # constants
     REFERENCE_5V=5.0
     MAX_NOTE_HOLD_TIME_MS=30000
@@ -108,11 +108,11 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 )
 
 # if INCLUDE_MIDI
-target_link_libraries(${PROJECT_NAME} 
+target_link_libraries(${PROJECT_NAME}
     tinyusb_device
     tinyusb_board
 )
-pico_enable_stdio_usb(${PROJECT_NAME} 0)
+pico_enable_stdio_usb(${PROJECT_NAME} 1)
 pico_enable_stdio_uart(${PROJECT_NAME} 1)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOVERSION = go1.21.11
 GOBIN = $(HOME)/go/bin
 GOINSTALLPATH = $(GOBIN)/$(GOVERSION)
 
-yoctocore: luascripts pico-extras build 
+yoctocore: luascripts pico-extras build
 	make -C build -j$(NPROCS)
 	echo "build success"
 	cp build/*.uf2 yoctocore.uf2
@@ -27,25 +27,25 @@ luascripts:
 lua:
 	lua web/static/globals.lua
 
-build: 
+build:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
+	cd build && cmake ..
 
 release:
 	mkdir -p build
 	cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
 
 envs:
-	export PICO_EXTRAS_PATH=/home/zns/pico/pico-extras 
-	export PICO_SDK_PATH=/home/zns/pico/pico-sdk 
+	export PICO_EXTRAS_PATH=/home/zns/pico/pico-extras
+	export PICO_SDK_PATH=/home/zns/pico/pico-sdk
 
 pico-extras:
 	git clone https://github.com/raspberrypi/pico-extras.git pico-extras
 	cd pico-extras && git checkout sdk-1.5.1
 	cd pico-extras && git submodule update -i
-	
+
 changebaud:
-	-curl localhost:7083 
+	-curl localhost:7083
 
 resetpico2:
 	-amidi -p $$(amidi -l | grep 'yoctocore\|zeptoboard\|ectocore' | awk '{print $$2}') -S "F0 64 69 73 6B 6D 6F 64 65 31 F7"
@@ -56,7 +56,7 @@ resetpico2:
 	sleep 0.1
 
 upload: resetpico2 changebaud yoctocore
-	./dev/upload.sh 
+	./dev/upload.sh
 
 
 clean:
@@ -74,7 +74,7 @@ ignore:
 
 web/localhost.pem:
 	go install -v filippo.io/mkcert@latest
-	cd web && mkcert -install 
+	cd web && mkcert -install
 	cd web && mkcert localhost
 
 .PHONY: web

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lua:
 
 build:
 	mkdir -p build
-	cd build && cmake ..
+	cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 release:
 	mkdir -p build

--- a/lib/midi_comm.h
+++ b/lib/midi_comm.h
@@ -13,6 +13,17 @@ typedef void (*callback_uint16)(uint16_t);
 typedef void (*callback_uint8_buffer)(uint8_t *buffer, int length);
 typedef void (*callback_void)();
 
+// TODO: put this in a usb_descriptors.h file
+enum
+    {
+        ITF_NUM_CDC            = 0,
+        ITF_NUM_CDC_DATA,
+        ITF_NUM_MIDI,
+        ITF_NUM_MIDI_STREAMING,
+        ITF_NUM_TOTAL
+    };
+
+
 uint32_t send_buffer_as_sysex(char *buffer, uint32_t bufsize) {
   uint8_t sysex_data[bufsize + 2];  // +2 for SysEx start and end bytes
 
@@ -22,7 +33,7 @@ uint32_t send_buffer_as_sysex(char *buffer, uint32_t bufsize) {
   }
   sysex_data[bufsize + 1] = 0xF7;  // End of SysEx
 
-  uint32_t v = tud_midi_n_stream_write(0, 0, sysex_data, sizeof(sysex_data));
+  uint32_t v = tud_midi_n_stream_write(ITF_NUM_MIDI, 0, sysex_data, sizeof(sysex_data));
   tud_task();
   return v;
 }
@@ -41,7 +52,7 @@ uint32_t send_text_as_sysex(const char *text) {
   sysex_data[text_length + 1] = 0xF7;  // End of SysEx
 
   // Call the stream write function with the SysEx message
-  uint32_t v = tud_midi_n_stream_write(0, 0, sysex_data, sizeof(sysex_data));
+  uint32_t v = tud_midi_n_stream_write(ITF_NUM_MIDI, 0, sysex_data, sizeof(sysex_data));
   tud_task();
   return v;
 }
@@ -55,7 +66,7 @@ void send_midi_clock() {
     midi_message[0] = 0xF8;  // Timing Clock command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -69,7 +80,7 @@ void send_midi_start() {
     midi_message[0] = 0xFA;  // Start command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -83,7 +94,7 @@ void send_midi_stop() {
     midi_message[0] = 0xFC;  // Stop command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -102,7 +113,7 @@ void send_midi_note_on(uint8_t note, uint8_t velocity) {
     midi_message[2] = velocity;        // Note velocity
 
     // Send the MIDI message
-    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }

--- a/lib/midi_comm.h
+++ b/lib/midi_comm.h
@@ -13,16 +13,6 @@ typedef void (*callback_uint16)(uint16_t);
 typedef void (*callback_uint8_buffer)(uint8_t *buffer, int length);
 typedef void (*callback_void)();
 
-// TODO: put this in a usb_descriptors.h file
-enum
-    {
-        ITF_NUM_CDC            = 0,
-        ITF_NUM_CDC_DATA,
-        ITF_NUM_MIDI,
-        ITF_NUM_MIDI_STREAMING,
-        ITF_NUM_TOTAL
-    };
-
 
 uint32_t send_buffer_as_sysex(char *buffer, uint32_t bufsize) {
   uint8_t sysex_data[bufsize + 2];  // +2 for SysEx start and end bytes
@@ -33,7 +23,7 @@ uint32_t send_buffer_as_sysex(char *buffer, uint32_t bufsize) {
   }
   sysex_data[bufsize + 1] = 0xF7;  // End of SysEx
 
-  uint32_t v = tud_midi_n_stream_write(ITF_NUM_MIDI, 0, sysex_data, sizeof(sysex_data));
+  uint32_t v = tud_midi_n_stream_write(0, 0, sysex_data, sizeof(sysex_data));
   tud_task();
   return v;
 }
@@ -52,7 +42,7 @@ uint32_t send_text_as_sysex(const char *text) {
   sysex_data[text_length + 1] = 0xF7;  // End of SysEx
 
   // Call the stream write function with the SysEx message
-  uint32_t v = tud_midi_n_stream_write(ITF_NUM_MIDI, 0, sysex_data, sizeof(sysex_data));
+  uint32_t v = tud_midi_n_stream_write(0, 0, sysex_data, sizeof(sysex_data));
   tud_task();
   return v;
 }
@@ -66,7 +56,7 @@ void send_midi_clock() {
     midi_message[0] = 0xF8;  // Timing Clock command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -80,7 +70,7 @@ void send_midi_start() {
     midi_message[0] = 0xFA;  // Start command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -94,7 +84,7 @@ void send_midi_stop() {
     midi_message[0] = 0xFC;  // Stop command
 
     // Send the MIDI message
-    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }
@@ -113,7 +103,7 @@ void send_midi_note_on(uint8_t note, uint8_t velocity) {
     midi_message[2] = velocity;        // Note velocity
 
     // Send the MIDI message
-    tud_midi_n_stream_write(ITF_NUM_MIDI, 0, midi_message, sizeof(midi_message));
+    tud_midi_n_stream_write(0, 0, midi_message, sizeof(midi_message));
     tud_task();
   }
 }

--- a/lib/usb_descriptors.c
+++ b/lib/usb_descriptors.c
@@ -35,36 +35,38 @@
  *   [MSB]       MIDI | HID | MSC | CDC          [LSB]
  */
 #define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
-#define USB_PID                                                      \
-  (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+#define USB_PID                                                         \
+  (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) |    \
    _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4))
 
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
 tusb_desc_device_t const desc_device = {
-    .bLength = sizeof(tusb_desc_device_t),
-    .bDescriptorType = TUSB_DESC_DEVICE,
-    .bcdUSB = 0x0200,
+  .bLength = sizeof(tusb_desc_device_t),
+  .bDescriptorType = TUSB_DESC_DEVICE,
+  .bcdUSB = 0x0200,
 
-    // NB: see https://github.com/espressif/esp-usb/blob/master/device/esp_tinyusb/usb_descriptors.c#L30
-    .bDeviceClass = TUSB_CLASS_MISC,
-    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol = MISC_PROTOCOL_IAD,
-    // .bDeviceClass = 0x00,
-    // .bDeviceSubClass = 0x00,
-    // .bDeviceProtocol = 0x00,
-    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+#if CFG_TUD_CDC
+  .bDeviceClass = TUSB_CLASS_MISC,
+  .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+  .bDeviceProtocol = MISC_PROTOCOL_IAD,
+#else
+  .bDeviceClass = 0x00,
+  .bDeviceSubClass = 0x00,
+  .bDeviceProtocol = 0x00,
+#endif
+  .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
 
-    .idVendor = 0xCafe,
-    .idProduct = USB_PID,
-    .bcdDevice = 0x0100,
+  .idVendor = 0xCafe,
+  .idProduct = USB_PID,
+  .bcdDevice = 0x0100,
 
-    .iManufacturer = 0x01,
-    .iProduct = 0x02,
-    .iSerialNumber = 0x03,
+  .iManufacturer = 0x01,
+  .iProduct = 0x02,
+  .iSerialNumber = 0x03,
 
-    .bNumConfigurations = 0x01};
+  .bNumConfigurations = 0x01};
 
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
@@ -76,20 +78,22 @@ uint8_t const* tud_descriptor_device_cb(void) {
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-// enum { ITF_NUM_MIDI = 0, ITF_NUM_MIDI_STREAMING, ITF_NUM_TOTAL };
-
+#if CFG_TUD_CDC
 enum
-    {
-        ITF_NUM_CDC            = 0,
-        ITF_NUM_CDC_DATA,
-        ITF_NUM_MIDI,
-        ITF_NUM_MIDI_STREAMING,
-        ITF_NUM_TOTAL
-    };
+  {
+    ITF_NUM_CDC            = 0,
+    ITF_NUM_CDC_DATA,
+    ITF_NUM_MIDI,
+    ITF_NUM_MIDI_STREAMING,
+    ITF_NUM_TOTAL
+  };
+#else
+enum { ITF_NUM_MIDI = 0, ITF_NUM_MIDI_STREAMING, ITF_NUM_TOTAL };
+#endif
 
-#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_MIDI_DESC_LEN)
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN + TUD_MIDI_DESC_LEN)
 
-/* #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X ||                               \
+/* #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X ||                            \
  *     CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
  * // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
  * // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
@@ -105,30 +109,33 @@ enum
 #define EPNUM_CDC_IN    0x82
 
 uint8_t const desc_fs_configuration[] = {
-    // Config number, interface count, string index, total length, attribute,
-    // power in mA
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
-                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+  // Config number, interface count, string index, total length, attribute,
+  // power in mA
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
+                        TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
-    // NB: see https://github.com/espressif/esp-usb/blob/master/device/esp_tinyusb/usb_descriptors.c#L217C1-L220C7
-    // Interface number, string index, EP Out & EP In address, EP size
-	TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+#if CFG_TUD_CDC
+  // Interface number, string index, EP Out & EP In address, EP size
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+#endif
 
-    // Interface number, string index, EP Out & EP In address, EP size
-    TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64)};
+  // Interface number, string index, EP Out & EP In address, EP size
+  TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64)};
 
 #if TUD_OPT_HIGH_SPEED
 uint8_t const desc_hs_configuration[] = {
-    // Config number, interface count, string index, total length, attribute,
-    // power in mA
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
-                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+  // Config number, interface count, string index, total length, attribute,
+  // power in mA
+  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
+                        TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
-    // Interface number, string index, EP Out & EP In address, EP size
-	TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 512),
+#if CFG_TUD_CDC
+  // Interface number, string index, EP Out & EP In address, EP size
+  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 512),
+#endif
 
-    // Interface number, string index, EP Out & EP In address, EP size
-    TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 512)};
+  // Interface number, string index, EP Out & EP In address, EP size
+  TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 512)};
 #endif
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
@@ -140,7 +147,7 @@ uint8_t const* tud_descriptor_configuration_cb(uint8_t index) {
 #if TUD_OPT_HIGH_SPEED
   // Although we are highspeed, host may be fullspeed.
   return (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_hs_configuration
-                                              : desc_fs_configuration;
+    : desc_fs_configuration;
 #else
   return desc_fs_configuration;
 #endif
@@ -152,24 +159,25 @@ uint8_t const* tud_descriptor_configuration_cb(uint8_t index) {
 
 // array of pointer to string descriptors
 char const* string_desc_arr[] = {
-    (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
-    "Raspberry Pi",              // 1: Manufacturer
+  (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
+  "Raspberry Pi",              // 1: Manufacturer
 #ifdef INCLUDE_BOARDCORE
-    "zeptoboard",  // 2: Product
+  "zeptoboard",  // 2: Product
 #endif
 #ifdef INCLUDE_ZEPTOCORE
-    "zeptocore",  // 2: Product
+  "zeptocore",  // 2: Product
 #endif
 #ifdef INCLUDE_ECTOCORE
-    "ectocore",  // 2: Product
+  "ectocore",  // 2: Product
 #endif
 #ifdef INCLUDE_YOCTOCORE
-    "yoctocore",  // 2: Product
+  "yoctocore",  // 2: Product
 #endif
-    "123456",  // 3: Serials, should use chip ID
+  "123456",  // 3: Serials, should use chip ID
 
-    // NB: see https://github.com/espressif/esp-usb/blob/master/device/esp_tinyusb/usb_descriptors.c#L97
-    "Yoctocore CDC Device" // 4: CDC Interface
+#if CFG_TUD_CDC
+  "Yoctocore CDC Device", // 4: CDC Interface
+#endif
 };
 
 static uint16_t _desc_str[32];

--- a/main.c
+++ b/main.c
@@ -826,6 +826,10 @@ int main() {
     uint32_t us = time_us_32();
 #ifdef INCLUDE_MIDI
     tud_task();
+    // NB: i'm really not sure this is really needed
+    if (tud_cdc_connected()) {
+        tud_cdc_write_flush();
+    }
     midi_comm_task(midi_sysex_callback, midi_note_on, midi_note_off,
                    midi_key_pressure, midi_cc, midi_program_change,
                    midi_channel_pressure, midi_pitch_bend, midi_start,

--- a/main.c
+++ b/main.c
@@ -826,10 +826,6 @@ int main() {
     uint32_t us = time_us_32();
 #ifdef INCLUDE_MIDI
     tud_task();
-    // NB: i'm really not sure this is really needed
-    if (tud_cdc_connected()) {
-        tud_cdc_write_flush();
-    }
     midi_comm_task(midi_sysex_callback, midi_note_on, midi_note_off,
                    midi_key_pressure, midi_cc, midi_program_change,
                    midi_channel_pressure, midi_pitch_bend, midi_start,

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -77,13 +77,17 @@ extern "C" {
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC             0
+#define CFG_TUD_CDC             1
 #define CFG_TUD_MSC             0
-#define CFG_TUD_HID             0 
-#define CFG_TUD_MIDI            1 
+#define CFG_TUD_HID             0
+#define CFG_TUD_MIDI            1
 #define CFG_TUD_VENDOR          0
 
-// MIDI FIFO size of TX and RX
+    // CDC Configuration
+#define CFG_TUD_CDC_RX_BUFSIZE    (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_TX_BUFSIZE    (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+    // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #define CFG_TUD_MIDI_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -83,11 +83,11 @@ extern "C" {
 #define CFG_TUD_MIDI            1
 #define CFG_TUD_VENDOR          0
 
-    // CDC Configuration
+// CDC Configuration
 #define CFG_TUD_CDC_RX_BUFSIZE    (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #define CFG_TUD_CDC_TX_BUFSIZE    (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
-    // MIDI FIFO size of TX and RX
+// MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #define CFG_TUD_MIDI_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
 

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -77,7 +77,7 @@ extern "C" {
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC             1
+#define CFG_TUD_CDC             PICO_STDIO_USB_ENABLE
 #define CFG_TUD_MSC             0
 #define CFG_TUD_HID             0
 #define CFG_TUD_MIDI            1


### PR DESCRIPTION
this defines the USB port as a composite one.

the device shows up both as a midi device:

```
$ aconnect -i -o -l
[...]
client 28: 'yoctocore' [type=kernel,card=3]
    0 'yoctocore2 MIDI 1'
	Connecting To: 128:0
	Connected From: 129:1
```

and as a USB serial one:
```
$ ls /dev/ttyACM*
/dev/ttyACM0
```

- `comms -serial` works
- pushing conf from the web editor works
- pulling conf from the device to the web editor doesn't yet