### PR TITLE
[DO_NOT_MERGE] fix: hanging serial cnnx, must read input

### DIFF
--- a/main.c
+++ b/main.c
@@ -49,6 +49,10 @@ static const uint32_t PIN_DCDC_PSM_CTRL = 23;
 #define DURATION_HOLD_LONG 1250
 #define FLASH_TARGET_OFFSET (5 * 256 * 1024)
 
+#if CFG_TUD_CDC
+char cdc_rx_buffer[CFG_TUD_CDC_RX_BUFSIZE];
+#endif
+
 //
 #include "ff.h" /* Obtains integer types */
 //
@@ -858,6 +862,16 @@ int main() {
       midi_receive_byte(ch);
     }
     timer_per[1] = time_us_32() - us;
+
+#if CFG_TUD_CDC
+    // process serial input
+    if (tud_cdc_connected()) {
+        int count = tud_cdc_read(cdc_rx_buffer, CFG_TUD_CDC_RX_BUFSIZE);
+        if (count) {
+            // printf("Received: %s\n", cdc_rx_buffer);
+        }
+    }
+#endif
 
     // process any mode change
     for (uint8_t i = 0; i < 8; i++) {

--- a/main.c
+++ b/main.c
@@ -49,10 +49,6 @@ static const uint32_t PIN_DCDC_PSM_CTRL = 23;
 #define DURATION_HOLD_LONG 1250
 #define FLASH_TARGET_OFFSET (5 * 256 * 1024)
 
-#if CFG_TUD_CDC
-char cdc_rx_buffer[CFG_TUD_CDC_RX_BUFSIZE];
-#endif
-
 //
 #include "ff.h" /* Obtains integer types */
 //
@@ -97,6 +93,11 @@ uint32_t time_per_iteration = 0;
 uint32_t timer_per[32];
 uint32_t lfo_ct_last[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 float lfo_index_acc[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+#if CFG_TUD_CDC
+char cdc_rx_buffer[CFG_TUD_CDC_RX_BUFSIZE];
+#endif
+
 // const clockDivisions = [
 //   "/512", "/256", "/128", "/64", "/32", "/16", "/8", "/4", "/2", "x1", "x2",
 //   "x3", "x4", "x6", "x8", "x12", "x16", "x24", "x48"


### PR DESCRIPTION
i had issues w/ the serial connection (`comms -serial`) being sometimes unresponsive and/or taking a while to be released when doing a `Ctrl-C`.

reading the incoming serial bytes regularly seems make it last much longer without hanging, but when it does hand its a crash.