### PR TITLE
add emacs project config (esp. indentation level)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+((c-mode
+  (c-basic-offset . 2)
+  (indent-tabs-mode . nil))
+ (c++-mode
+  (c-basic-offset . 2)
+  (indent-tabs-mode . nil)))


### PR DESCRIPTION
adds a small local config for emacs users (its-a-me!) so that emacs' default C indentation levels don't mess w/ this project's.